### PR TITLE
KAN-129 Fix subnet tags for ALB controller

### DIFF
--- a/kubernetes_manifests/bootstraps/helm_values/alb_controller.yaml
+++ b/kubernetes_manifests/bootstraps/helm_values/alb_controller.yaml
@@ -1,4 +1,4 @@
-clusterName: eks-from-terraform
+clusterName: ipv6-eks-createby-terraform
 
 serviceAccount:
   name: alb-controller-irsa-sa


### PR DESCRIPTION
ALB controller이 인식하는 subnet tag 값을 수정합니다.