### PR TITLE
Change EKS ipv6 public subnet route table

### DIFF
--- a/ipv6_eks/_module/eks_ipv6_vpc/route_tables.tf
+++ b/ipv6_eks/_module/eks_ipv6_vpc/route_tables.tf
@@ -48,12 +48,12 @@ resource "aws_route" "public_ipv4_internet_gateway" {
   gateway_id             = aws_internet_gateway.main.id
 }
 
-resource "aws_route" "public_ipv6_egress_only_gateway" {
+resource "aws_route" "public_ipv6_gateway" {
   for_each = var.public_subnets
 
   route_table_id              = aws_route_table.public[each.key].id
   destination_ipv6_cidr_block = "::/0"
-  egress_only_gateway_id      = aws_egress_only_internet_gateway.this.id
+  gateway_id                  = aws_internet_gateway.main.id
 }
 
 ################################################################################


### PR DESCRIPTION
- 이유: EKS IPv6 ALB주소를 외부에서 들어올 수 있도록, EKS VPC public subnet route table을 수정합니다. 
- 수정내용: [::] 라우팅 규칙을 egress-only에서 internet gateway로 변경합니다.