### PR TITLE
Remove public IPv4 at EKS private subnets

### DIFF
--- a/ipv6_eks/_module/eks_ipv6_vpc/subnets.tf
+++ b/ipv6_eks/_module/eks_ipv6_vpc/subnets.tf
@@ -28,8 +28,7 @@ resource "aws_subnet" "private" {
   availability_zone = each.value["az"]
 
   // IPv4
-  cidr_block              = each.value["ipv4_cidr"]
-  map_public_ip_on_launch = true
+  cidr_block = each.value["ipv4_cidr"]
 
   // IPv6
   assign_ipv6_address_on_creation                = true


### PR DESCRIPTION
EKS VPC private subnet에 public IPv4 자동할당 설정을 제거합니다.